### PR TITLE
search() function should return the offset, not a number of matches

### DIFF
--- a/src/utils/hyperscan.cc
+++ b/src/utils/hyperscan.cc
@@ -57,7 +57,7 @@ bool HyperscanPm::compile(std::string *error) {
 
     // The Hyperscan compiler takes its patterns in a group of arrays.
     std::vector<const char *> pats;
-    std::vector<unsigned> flags(num_patterns, HS_FLAG_DOTALL | HS_FLAG_MULTILINE | HS_FLAG_SOM_LEFTMOST);
+    std::vector<unsigned> flags(num_patterns, HS_FLAG_SINGLEMATCH);
     std::vector<unsigned> ids;
 
     for (const auto &p : patterns) {
@@ -152,7 +152,7 @@ int HyperscanPm::search(const char *t, unsigned int tlen, std::vector<std::strin
         return -1;
     }
 
-    return ctx.num_matches;
+    return ctx.num_matches > 0 ? ctx.offset : -1;
 }
 
 const char *HyperscanPm::getPatternById(unsigned int patId) const {

--- a/src/utils/hyperscan.h
+++ b/src/utils/hyperscan.h
@@ -41,7 +41,7 @@ class HyperscanPm {
     int search(const char *t, 
                 unsigned int tlen, 
                 std::vector<std::string>& matches,
-                bool terminateAfter1stMatch = false);
+                bool terminateAfter1stMatch = true);
 
     const char *getPatternById(unsigned int patId) const;
 


### PR DESCRIPTION
The `@pm` operator means that the search function returns the offset, or `-1` if nothing is found. See the `acmp_process_quick` implementation in `src/utils/acmp.cc` for example.